### PR TITLE
Add option to register Custom AddonRepository implementations

### DIFF
--- a/container-api/src/main/java/org/jboss/forge/furnace/Furnace.java
+++ b/container-api/src/main/java/org/jboss/forge/furnace/Furnace.java
@@ -78,6 +78,12 @@ public interface Furnace
    public AddonRepository addRepository(AddonRepositoryMode mode, File repository);
 
    /**
+    * Add an {@link AddonRepository} to be scanned for deployed and enabled {@link Addon} instances. This method must
+    * not be called once {@link Furnace} is started.
+    */
+   public AddonRepository addRepository(AddonRepository repository);
+
+   /**
     * Get the current runtime API version of {@link Furnace}.
     */
    public Version getVersion();

--- a/container/src/main/java/org/jboss/forge/furnace/impl/FurnaceImpl.java
+++ b/container/src/main/java/org/jboss/forge/furnace/impl/FurnaceImpl.java
@@ -344,17 +344,28 @@ public class FurnaceImpl implements Furnace
       Assert.notNull(mode, "Addon repository mode must not be null.");
       Assert.notNull(directory, "Addon repository directory must not be null.");
 
-      for (AddonRepository registeredRepo : repositories)
-      {
-         if (registeredRepo.getRootDirectory().equals(directory))
-         {
-            throw new IllegalArgumentException("There is already a repository defined with this path: " + directory);
-         }
-      }
       AddonRepository repository = AddonRepositoryImpl.forDirectory(this, directory);
 
       if (mode.isImmutable())
          repository = new ImmutableAddonRepository(repository);
+
+      return addRepository(repository);
+   }
+
+   @Override
+   public AddonRepository addRepository(AddonRepository repository)
+   {
+      assertNotAlive();
+
+      Assert.notNull(repository, "Addon repository must not be null.");
+
+      for (AddonRepository registeredRepo : repositories)
+      {
+         if (registeredRepo.getRootDirectory().equals(repository.getRootDirectory()))
+         {
+            throw new IllegalArgumentException("There is already a repository defined with this path: " + repository.getRootDirectory());
+         }
+      }
 
       this.repositories.add(repository);
       lastRepoVersionSeen.put(repository, 0);

--- a/container/src/test/java/org/jboss/forge/furnace/FurnaceImplTest.java
+++ b/container/src/test/java/org/jboss/forge/furnace/FurnaceImplTest.java
@@ -1,9 +1,18 @@
 package org.jboss.forge.furnace;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
 
+import org.jboss.forge.furnace.addons.AddonId;
 import org.jboss.forge.furnace.impl.FurnaceImpl;
+import org.jboss.forge.furnace.repositories.AddonDependencyEntry;
+import org.jboss.forge.furnace.repositories.AddonRepository;
 import org.jboss.forge.furnace.repositories.AddonRepositoryMode;
+import org.jboss.forge.furnace.versions.Version;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class FurnaceImplTest
@@ -18,5 +27,124 @@ public class FurnaceImplTest
    public void shouldValidateAddRepositoryArgumentDirectory() throws Exception {
       Furnace f = new FurnaceImpl();
       f.addRepository(AddonRepositoryMode.IMMUTABLE, null);
+   }
+
+   @Test(expected = IllegalArgumentException.class)
+   public void shouldValidateAddRepositoryArgumentRepository() throws Exception {
+      Furnace f = new FurnaceImpl();
+      f.addRepository((AddonRepository)null);
+   }
+
+   @Test(expected = IllegalArgumentException.class)
+   public void shouldNotAllowMultipleDiskRepositoriesWithSameRootDirectory() throws Exception {
+      Furnace f = new FurnaceImpl();
+
+      f.addRepository(AddonRepositoryMode.IMMUTABLE, new File("target"));
+      f.addRepository(AddonRepositoryMode.IMMUTABLE, new File("target"));
+   }
+
+   @Test(expected = IllegalArgumentException.class)
+   public void shouldNotAllowMultipleRepositoriesWithSameRootDirectory() throws Exception {
+      Furnace f = new FurnaceImpl();
+
+      f.addRepository(AddonRepositoryMode.IMMUTABLE, new File("target"));
+      f.addRepository(new TestAddonRepository(new File("target")));
+   }
+
+   @Test
+   public void shouldAllowToAddDiskRepository() throws Exception {
+      Furnace f = new FurnaceImpl();
+
+      f.addRepository(AddonRepositoryMode.IMMUTABLE, new File("target"));
+
+      Assert.assertEquals(1, f.getRepositories().size());
+   }
+
+   @Test
+   public void shouldAllowToAddCustomRepository() throws Exception {
+      Furnace f = new FurnaceImpl();
+
+      AddonRepository repository = new TestAddonRepository(new File("target"));
+      f.addRepository(repository);
+
+      Assert.assertEquals(1, f.getRepositories().size());
+      Assert.assertEquals(repository, f.getRepositories().get(0));
+   }
+
+   private static class TestAddonRepository implements AddonRepository {
+      private Date modified;
+      private File rootDir;
+
+      public TestAddonRepository(File rootDir)
+      {
+         this.modified = new Date();
+         this.rootDir = rootDir;
+      }
+
+      @Override
+      public File getAddonBaseDir(AddonId addon)
+      {
+         return null;
+      }
+
+      @Override
+      public Set<AddonDependencyEntry> getAddonDependencies(AddonId addon)
+      {
+         return Collections.emptySet();
+      }
+
+      @Override
+      public File getAddonDescriptor(AddonId addon)
+      {
+         return null;
+      }
+
+      @Override
+      public List<File> getAddonResources(AddonId addon)
+      {
+         return Collections.emptyList();
+      }
+
+      @Override
+      public File getRootDirectory()
+      {
+         return rootDir;
+      }
+
+      @Override
+      public boolean isDeployed(AddonId addon)
+      {
+         return false;
+      }
+
+      @Override
+      public boolean isEnabled(AddonId addon)
+      {
+         return false;
+      }
+
+      @Override
+      public List<AddonId> listEnabled()
+      {
+         return Collections.emptyList();
+      }
+
+      @Override
+      public List<AddonId> listEnabledCompatibleWithVersion(Version version)
+      {
+         return null;
+      }
+
+      @Override
+      public Date getLastModified()
+      {
+         return modified;
+      }
+
+      @Override
+      public int getVersion()
+      {
+         return 0;
+      }
    }
 }


### PR DESCRIPTION
With this you can create your own non disk based repository, e.g. a Repository backed by a ClassLoader.

The AddonRepository interface is still fairly tied to Disk via e.g 

``` java
File getAddonDescriptor() {}
List<File> getAddonResources(AddonId addon);
File getRootDirectory();
```

These limitations can be worked around for the time being. A future revision of the interface might want to abstract that away. 
