### PR TITLE
Expose java.lang methods if directly specified by Types

### DIFF
--- a/proxy/src/main/java/org/jboss/forge/furnace/proxy/ClassLoaderAdapterCallback.java
+++ b/proxy/src/main/java/org/jboss/forge/furnace/proxy/ClassLoaderAdapterCallback.java
@@ -718,7 +718,8 @@ public class ClassLoaderAdapterCallback implements MethodHandler, ForgeProxy
                                  || ("toString".equals(method.getName()) && method.getParameterTypes().length == 0)
                                  || isEquals(method)
                                  || isHashCode(method)
-                                 || isAutoCloseableClose(method))
+                                 || isAutoCloseableClose(method)
+                                 || Arrays.contains(types,  method.getDeclaringClass()))
                            return true;
                         return false;
                      }


### PR DESCRIPTION
Don't ask me exactly how, because I didn't manage to reproduce it in a test case, but.. 

While bootstrapping Furnace SE and adding my own custom AddonRepository, I end up with a situation where a AbstractMethodError is thrown from here:
https://github.com/forge/furnace/blob/master/container/src/main/java/org/jboss/forge/furnace/impl/graph/AddonGraph.java#L16

It happens when both vertex.getVersion() and version is a Proxy in the version.compareTo(vertex.getVersion()) call. 

Looking at the code, the Proxy does not handle compareTo even tho the specified type to enhance is Comparable. This patch fixes that.
