### PR TITLE
FURNACE-114 pluggable dirty checking

### DIFF
--- a/container/src/main/java/org/jboss/forge/furnace/impl/addons/AddonRepositoryImpl.java
+++ b/container/src/main/java/org/jboss/forge/furnace/impl/addons/AddonRepositoryImpl.java
@@ -28,7 +28,7 @@ import org.jboss.forge.furnace.versions.Versions;
  * @author <a href="mailto:koen.aers@gmail.com">Koen Aers</a>
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
  */
-public final class AddonRepositoryImpl implements MutableAddonRepository
+public final class AddonRepositoryImpl implements MutableAddonRepository, DirtyCheckableRepository
 {
 
    private static final String DEFAULT_ADDON_DIR = ".forge/addons";
@@ -216,5 +216,11 @@ public final class AddonRepositoryImpl implements MutableAddonRepository
    public Date getLastModified()
    {
       return new Date(addonDir.lastModified());
+   }
+
+   @Override
+   public DirtyChecker createDirtyChecker()
+   {
+      return new CompositeDirtyChecker(storageRepository.createDirtyChecker(), stateRepository.createDirtyChecker());
    }
 }

--- a/container/src/main/java/org/jboss/forge/furnace/impl/addons/AddonRepositoryStateStrategyImpl.java
+++ b/container/src/main/java/org/jboss/forge/furnace/impl/addons/AddonRepositoryStateStrategyImpl.java
@@ -290,4 +290,9 @@ public final class AddonRepositoryStateStrategyImpl extends AbstractFileSystemAd
    {
       version++;
    }
+
+   @Override
+   public DirtyChecker createDirtyChecker() {
+      return new VersionDirtyChecker(this::getVersion);
+   }
 }

--- a/container/src/main/java/org/jboss/forge/furnace/impl/addons/AddonRepositoryStorageStrategyImpl.java
+++ b/container/src/main/java/org/jboss/forge/furnace/impl/addons/AddonRepositoryStorageStrategyImpl.java
@@ -325,4 +325,9 @@ public final class AddonRepositoryStorageStrategyImpl extends AbstractFileSystem
 
       return installed;
    }
+
+   @Override
+   public DirtyChecker createDirtyChecker() {
+      return new FileSystemDirtyChecker(addonDir);
+   }
 }

--- a/container/src/main/java/org/jboss/forge/furnace/impl/addons/CompositeDirtyChecker.java
+++ b/container/src/main/java/org/jboss/forge/furnace/impl/addons/CompositeDirtyChecker.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.furnace.impl.addons;
+
+/**
+ * Composite dirty checker to check other dirty checkers.
+ *
+ * @author <a href="mailto:bsideup@gmail.com">Sergei Egorov</a>
+ */
+public class CompositeDirtyChecker implements DirtyChecker
+{
+
+    private final DirtyChecker[] dirtyCheckers;
+
+    public CompositeDirtyChecker(DirtyChecker... dirtyCheckers)
+    {
+        this.dirtyCheckers = dirtyCheckers;
+    }
+
+    @Override
+    public boolean isDirty()
+    {
+        for (DirtyChecker dirtyChecker : dirtyCheckers)
+        {
+            if (dirtyChecker.isDirty())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public void resetDirtyStatus()
+    {
+        for (DirtyChecker dirtyChecker : dirtyCheckers)
+        {
+            dirtyChecker.resetDirtyStatus();
+        }
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        for (DirtyChecker dirtyChecker : dirtyCheckers)
+        {
+            dirtyChecker.close();
+        }
+    }
+}

--- a/container/src/main/java/org/jboss/forge/furnace/impl/addons/DirtyCheckableRepository.java
+++ b/container/src/main/java/org/jboss/forge/furnace/impl/addons/DirtyCheckableRepository.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.furnace.impl.addons;
+
+/**
+ * Used to allow dirty checks on repositories.
+ *
+ * @author <a href="mailto:bsideup@gmail.com">Sergei Egorov</a>
+ */
+public interface DirtyCheckableRepository
+{
+    DirtyChecker createDirtyChecker();
+}

--- a/container/src/main/java/org/jboss/forge/furnace/impl/addons/DirtyChecker.java
+++ b/container/src/main/java/org/jboss/forge/furnace/impl/addons/DirtyChecker.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.furnace.impl.addons;
+
+/**
+ * Used to check dirtiness.
+ *
+ * @author <a href="mailto:bsideup@gmail.com">Sergei Egorov</a>
+ */
+public interface DirtyChecker extends AutoCloseable
+{
+
+    boolean isDirty();
+
+    default void resetDirtyStatus()
+    {
+    }
+
+    @Override
+    default void close() throws Exception
+    {
+    }
+}

--- a/container/src/main/java/org/jboss/forge/furnace/impl/addons/FileSystemDirtyChecker.java
+++ b/container/src/main/java/org/jboss/forge/furnace/impl/addons/FileSystemDirtyChecker.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.furnace.impl.addons;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * File system based dirty checker.
+ *
+ * @author <a href="mailto:bsideup@gmail.com">Sergei Egorov</a>
+ */
+public class FileSystemDirtyChecker extends LazyDirtyChecker
+{
+    private static Logger logger = Logger.getLogger(FileSystemDirtyChecker.class.getName());
+
+    private final File directory;
+
+    private WatchService watcher;
+
+    public FileSystemDirtyChecker(File directory)
+    {
+        this.directory = directory;
+    }
+
+    @Override
+    protected void init()
+    {
+        try
+        {
+            watcher = FileSystems.getDefault().newWatchService();
+        }
+        catch (IOException e)
+        {
+            logger.log(Level.WARNING, "File monitoring could not be started.", e);
+            return;
+        }
+
+        try
+        {
+            if ((directory.exists() && directory.isDirectory()) || directory.mkdirs())
+            {
+                directory.toPath().register(watcher,
+                        StandardWatchEventKinds.ENTRY_MODIFY,
+                        StandardWatchEventKinds.ENTRY_CREATE,
+                        StandardWatchEventKinds.ENTRY_DELETE,
+                        StandardWatchEventKinds.OVERFLOW);
+                logger.log(Level.FINE, "Monitoring repository [" + directory.toString() + "] for file changes.");
+            }
+            else
+            {
+                logger.log(Level.WARNING, "Cannot monitor repository [" + directory
+                        + "] for changes because it is not a directory.");
+            }
+        }
+        catch (IOException e)
+        {
+            logger.log(Level.WARNING, "Could not monitor repository [" + directory.toString() + "] for file changes.",
+                    e);
+        }
+    }
+
+    @Override
+    protected boolean isDirtyInternal()
+    {
+        if (watcher == null)
+        {
+            return false;
+        }
+
+        boolean dirty = false;
+        WatchKey key = watcher.poll();
+        while (key != null)
+        {
+            List<WatchEvent<?>> events = key.pollEvents();
+            if (!events.isEmpty())
+            {
+                logger.log(Level.FINE, "Detected changes in repository ["
+                        + events.iterator().next().context()
+                        + "].");
+                dirty = true;
+            }
+            key = watcher.poll();
+        }
+
+        return dirty;
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        if (watcher != null)
+        {
+            watcher.close();
+        }
+    }
+}

--- a/container/src/main/java/org/jboss/forge/furnace/impl/addons/LazyDirtyChecker.java
+++ b/container/src/main/java/org/jboss/forge/furnace/impl/addons/LazyDirtyChecker.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.furnace.impl.addons;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Dirty checker with lazy initialization.
+ *
+ * @author <a href="mailto:bsideup@gmail.com">Sergei Egorov</a>
+ */
+public abstract class LazyDirtyChecker implements DirtyChecker
+{
+
+    protected final AtomicBoolean initialized = new AtomicBoolean(false);
+
+    abstract protected void init();
+
+    abstract protected boolean isDirtyInternal();
+
+    @Override
+    public final boolean isDirty()
+    {
+        if (initialized.compareAndSet(false, true))
+            init();
+
+        return isDirtyInternal();
+    }
+}

--- a/container/src/main/java/org/jboss/forge/furnace/impl/addons/MutableAddonRepositoryStateStrategy.java
+++ b/container/src/main/java/org/jboss/forge/furnace/impl/addons/MutableAddonRepositoryStateStrategy.java
@@ -16,7 +16,7 @@ import org.jboss.forge.furnace.addons.AddonId;
  * @author <a href="mailto:koen.aers@gmail.com">Koen Aers</a>
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
  */
-public interface MutableAddonRepositoryStateStrategy extends AddonRepositoryStateStrategy
+public interface MutableAddonRepositoryStateStrategy extends AddonRepositoryStateStrategy, DirtyCheckableRepository
 {
    public boolean disable(final AddonId addon);
 

--- a/container/src/main/java/org/jboss/forge/furnace/impl/addons/MutableAddonRepositoryStorageStrategy.java
+++ b/container/src/main/java/org/jboss/forge/furnace/impl/addons/MutableAddonRepositoryStorageStrategy.java
@@ -19,7 +19,7 @@ import java.io.File;
  * @author <a href="mailto:koen.aers@gmail.com">Koen Aers</a>
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
  */
-public interface MutableAddonRepositoryStorageStrategy extends AddonRepositoryStorageStrategy
+public interface MutableAddonRepositoryStorageStrategy extends AddonRepositoryStorageStrategy, DirtyCheckableRepository
 {
    public boolean deploy(AddonId addon, Iterable<AddonDependencyEntry> dependencies, Iterable<File> resourceJars);
 

--- a/container/src/main/java/org/jboss/forge/furnace/impl/addons/VersionDirtyChecker.java
+++ b/container/src/main/java/org/jboss/forge/furnace/impl/addons/VersionDirtyChecker.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.jboss.forge.furnace.impl.addons;
+
+import java.util.function.Supplier;
+
+/**
+ * Version-based dirty checker.
+ *
+ * @author <a href="mailto:bsideup@gmail.com">Sergei Egorov</a>
+ */
+public class VersionDirtyChecker implements DirtyChecker
+{
+
+    private final Supplier<Integer> versionSupplier;
+
+    private int lastRepoVersionSeen = 0;
+
+    public VersionDirtyChecker(Supplier<Integer> versionSupplier)
+    {
+        this.versionSupplier = versionSupplier;
+    }
+
+    @Override
+    public boolean isDirty()
+    {
+        return versionSupplier.get() > lastRepoVersionSeen;
+    }
+
+    @Override
+    public void resetDirtyStatus()
+    {
+        lastRepoVersionSeen = versionSupplier.get();
+    }
+}

--- a/container/src/test/java/org/jboss/forge/furnace/AddonRepositoryImplTest.java
+++ b/container/src/test/java/org/jboss/forge/furnace/AddonRepositoryImplTest.java
@@ -296,5 +296,11 @@ public class AddonRepositoryImplTest
       {
          return version.get();
       }
+
+      @Override
+      public DirtyChecker createDirtyChecker()
+      {
+         return new VersionDirtyChecker(this::getVersion);
+      }
    }
 }


### PR DESCRIPTION
Right now Furnace by default does two types of dirty checking - version checking and file system watching. These can be extracted, plus dirty checking mechanism can be pluggable, i.e. for non-filesystem implementations of the storage.

Depends on #33