### PR TITLE
FURNACE-127: fixed NPE when relativePath is empty

### DIFF
--- a/manager/resolver/maven/src/main/java/org/jboss/forge/furnace/manager/maven/ClasspathWorkspaceReader.java
+++ b/manager/resolver/maven/src/main/java/org/jboss/forge/furnace/manager/maven/ClasspathWorkspaceReader.java
@@ -419,9 +419,12 @@ public class ClasspathWorkspaceReader implements WorkspaceReader
             {
                Xpp3Dom relativePathNode = parent.getChild("relativePath");
                String relativePath = (relativePathNode == null) ? "../pom.xml" : relativePathNode.getValue();
-               File parentPom = pomFile.getParentFile().toPath().resolve(relativePath).toFile();
-               if (parentPom.isFile())
-                  result = createFoundModules(parentPom);
+               if (relativePath != null)
+               {
+                   File parentPom = pomFile.getParentFile().toPath().resolve(relativePath).toFile();
+                   if (parentPom.isFile())
+                       result = createFoundModules(parentPom);
+               }
             }
          }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/FURNACE-127